### PR TITLE
Switch module path to github.com/kemsta/go-easyrsa/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/kemsta/go-easyrsa/actions/workflows/test.yml/badge.svg)](https://github.com/kemsta/go-easyrsa/actions/workflows/test.yml)
 [![Coverage Status](https://coveralls.io/repos/github/kemsta/go-easyrsa/badge.svg?branch=master)](https://coveralls.io/github/kemsta/go-easyrsa?branch=master)
-[![GoDoc](https://pkg.go.dev/badge/github.com/kemsta/go-easyrsa.svg)](https://pkg.go.dev/github.com/kemsta/go-easyrsa)
+[![GoDoc](https://pkg.go.dev/badge/github.com/kemsta/go-easyrsa/v2.svg)](https://pkg.go.dev/github.com/kemsta/go-easyrsa/v2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 A drop-in replacement for [easy-rsa](https://github.com/OpenVPN/easy-rsa) as a Go library - no shell scripts, no `openssl` subprocess, same PKI directory layout.
@@ -65,7 +65,7 @@ For users who still want the tiny v1-style command UX, there is also a separate 
 ### Installation
 
 ```bash
-go get github.com/kemsta/go-easyrsa@latest
+go get github.com/kemsta/go-easyrsa/v2@latest
 ```
 
 ### Quick Start
@@ -77,7 +77,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/kemsta/go-easyrsa/pki"
+    "github.com/kemsta/go-easyrsa/v2/pki"
 )
 
 func main() {
@@ -218,7 +218,7 @@ dh, err := p.GenDH(2048)
 ### 🔌 Custom Storage
 
 ```go
-import "github.com/kemsta/go-easyrsa/storage/memory"
+import "github.com/kemsta/go-easyrsa/v2/storage/memory"
 
 // In-memory backend - ideal for tests
 ks, csr, idx, sp, crl := memory.New()

--- a/cmd/go-easyrsa-legacy-cli/go.mod
+++ b/cmd/go-easyrsa-legacy-cli/go.mod
@@ -1,9 +1,9 @@
-module github.com/kemsta/go-easyrsa/cmd/go-easyrsa-legacy-cli
+module github.com/kemsta/go-easyrsa/v2/cmd/go-easyrsa-legacy-cli
 
 go 1.25.0
 
 require (
-	github.com/kemsta/go-easyrsa v1.0.2
+	github.com/kemsta/go-easyrsa/v2 v2.1.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 )
@@ -20,4 +20,4 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.7.0 // indirect
 )
 
-replace github.com/kemsta/go-easyrsa => ../..
+replace github.com/kemsta/go-easyrsa/v2 => ../..

--- a/cmd/go-easyrsa-legacy-cli/main.go
+++ b/cmd/go-easyrsa-legacy-cli/main.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/pki"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/pki"
 )
 
 const legacyValidityDays = 99 * 365

--- a/cmd/go-easyrsa-legacy-cli/main_test.go
+++ b/cmd/go-easyrsa-legacy-cli/main_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/cert"
+	"github.com/kemsta/go-easyrsa/v2/cert"
 )
 
 func TestCLI_BuildCA(t *testing.T) {

--- a/cmd/go-easyrsa-legacy-cli/testutil_test.go
+++ b/cmd/go-easyrsa-legacy-cli/testutil_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/pki"
+	"github.com/kemsta/go-easyrsa/v2/pki"
 )
 
 func runCLI(t *testing.T, args ...string) (string, error) {

--- a/cmd/go-easyrsa-migrate/go.mod
+++ b/cmd/go-easyrsa-migrate/go.mod
@@ -1,9 +1,9 @@
-module github.com/kemsta/go-easyrsa/cmd/go-easyrsa-migrate
+module github.com/kemsta/go-easyrsa/v2/cmd/go-easyrsa-migrate
 
 go 1.25.0
 
 require (
-	github.com/kemsta/go-easyrsa v1.0.2
+	github.com/kemsta/go-easyrsa/v2 v2.1.0
 	github.com/spf13/cobra v1.10.2
 )
 
@@ -15,4 +15,4 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.7.0 // indirect
 )
 
-replace github.com/kemsta/go-easyrsa => ../..
+replace github.com/kemsta/go-easyrsa/v2 => ../..

--- a/cmd/go-easyrsa-migrate/main.go
+++ b/cmd/go-easyrsa-migrate/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kemsta/go-easyrsa/pki"
+	"github.com/kemsta/go-easyrsa/v2/pki"
 )
 
 func main() {

--- a/cmd/go-easyrsa-migrate/main_test.go
+++ b/cmd/go-easyrsa-migrate/main_test.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
-	fsstore "github.com/kemsta/go-easyrsa/storage/fs"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	fsstore "github.com/kemsta/go-easyrsa/v2/storage/fs"
 )
 
 func TestCLI_MigratesLegacyToFS(t *testing.T) {

--- a/crypto/dh_test.go
+++ b/crypto/dh_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	pkicrypto "github.com/kemsta/go-easyrsa/crypto"
+	pkicrypto "github.com/kemsta/go-easyrsa/v2/crypto"
 )
 
 func TestGenDHParams_Basic(t *testing.T) {

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	pkicrypto "github.com/kemsta/go-easyrsa/crypto"
+	pkicrypto "github.com/kemsta/go-easyrsa/v2/crypto"
 )
 
 func TestGenKey_RSA(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kemsta/go-easyrsa
+module github.com/kemsta/go-easyrsa/v2
 
 go 1.25.0
 

--- a/internal/testutil/legacy_fixture.go
+++ b/internal/testutil/legacy_fixture.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	pkicrypto "github.com/kemsta/go-easyrsa/crypto"
-	"github.com/kemsta/go-easyrsa/pki"
-	"github.com/kemsta/go-easyrsa/storage/memory"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	pkicrypto "github.com/kemsta/go-easyrsa/v2/crypto"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage/memory"
 )
 
 // LegacyFixture contains a v1-style PKI tree written to disk for tests.

--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -1,6 +1,6 @@
 package migration
 
-import "github.com/kemsta/go-easyrsa/pki"
+import "github.com/kemsta/go-easyrsa/v2/pki"
 
 // Migrate exports the source PKI metadata and streams its pairs into the target PKI.
 func Migrate(source, target *pki.PKI) error {

--- a/migration/migrate_test.go
+++ b/migration/migrate_test.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/migration"
-	"github.com/kemsta/go-easyrsa/pki"
-	"github.com/kemsta/go-easyrsa/storage"
-	"github.com/kemsta/go-easyrsa/storage/memory"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/migration"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage/memory"
 )
 
 func TestMigrate_LegacyToFS(t *testing.T) {

--- a/migration/testutil_test.go
+++ b/migration/testutil_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/pki"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 func collectPairs(t *testing.T, pk *pki.PKI) []*cert.Pair {

--- a/pki/ca.go
+++ b/pki/ca.go
@@ -9,9 +9,9 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	pkicrypto "github.com/kemsta/go-easyrsa/crypto"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	pkicrypto "github.com/kemsta/go-easyrsa/v2/crypto"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // ShowCA returns the CA certificate pair.

--- a/pki/cert.go
+++ b/pki/cert.go
@@ -5,9 +5,9 @@ import (
 	"crypto/x509"
 	"time"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	pkicrypto "github.com/kemsta/go-easyrsa/crypto"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	pkicrypto "github.com/kemsta/go-easyrsa/v2/crypto"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // BuildClientFull generates a client key and issues a signed client certificate.

--- a/pki/clean.go
+++ b/pki/clean.go
@@ -1,7 +1,7 @@
 package pki
 
 import (
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // Cleaner is an optional interface that storage implementations may satisfy

--- a/pki/csr.go
+++ b/pki/csr.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	pkicrypto "github.com/kemsta/go-easyrsa/crypto"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	pkicrypto "github.com/kemsta/go-easyrsa/v2/crypto"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // GenReq generates a private key and a Certificate Signing Request.
@@ -244,4 +244,3 @@ func (p *PKI) SignReq(name string, certType cert.CertType, opts ...Option) (*cer
 
 	return pair, nil
 }
-

--- a/pki/export.go
+++ b/pki/export.go
@@ -9,8 +9,8 @@ import (
 	"go.mozilla.org/pkcs7"
 	gopkcs12 "software.sslmate.com/src/go-pkcs12"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	pkicrypto "github.com/kemsta/go-easyrsa/crypto"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	pkicrypto "github.com/kemsta/go-easyrsa/v2/crypto"
 )
 
 // ExportP12 exports the named certificate and key as a PKCS#12 bundle.

--- a/pki/helpers.go
+++ b/pki/helpers.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // pemEncodeCert PEM-encodes a DER certificate.

--- a/pki/inspect.go
+++ b/pki/inspect.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // ShowCert returns the certificate pair for the given name.

--- a/pki/pki.go
+++ b/pki/pki.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kemsta/go-easyrsa/storage"
-	fsstore "github.com/kemsta/go-easyrsa/storage/fs"
-	legacystore "github.com/kemsta/go-easyrsa/storage/legacy"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	fsstore "github.com/kemsta/go-easyrsa/v2/storage/fs"
+	legacystore "github.com/kemsta/go-easyrsa/v2/storage/legacy"
 )
 
 // PKI orchestrates all certificate operations.

--- a/pki/pki_test.go
+++ b/pki/pki_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
-	"github.com/kemsta/go-easyrsa/storage"
-	"github.com/kemsta/go-easyrsa/storage/memory"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage/memory"
 )
 
 // --- Test helpers & mock types ---

--- a/pki/revoke.go
+++ b/pki/revoke.go
@@ -10,9 +10,9 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	pkicrypto "github.com/kemsta/go-easyrsa/crypto"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	pkicrypto "github.com/kemsta/go-easyrsa/v2/crypto"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // Revoke revokes all certificates stored under the given name.

--- a/pki/snapshot.go
+++ b/pki/snapshot.go
@@ -7,8 +7,8 @@ import (
 	"math/big"
 	"sort"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // Snapshot is a storage-agnostic PKI transfer representation for metadata.

--- a/pki/snapshot_extra_test.go
+++ b/pki/snapshot_extra_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
-	fsstore "github.com/kemsta/go-easyrsa/storage/fs"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	fsstore "github.com/kemsta/go-easyrsa/v2/storage/fs"
 )
 
 func TestExportSnapshot_WithoutCRL(t *testing.T) {

--- a/pki/snapshot_test.go
+++ b/pki/snapshot_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
-	"github.com/kemsta/go-easyrsa/storage"
-	"github.com/kemsta/go-easyrsa/storage/memory"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage/memory"
 )
 
 func TestExportSnapshot_LegacyContainsHistoryAndMetadata(t *testing.T) {

--- a/pki/testutil_test.go
+++ b/pki/testutil_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/pki"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 func collectPairs(t *testing.T, pk *pki.PKI) []*cert.Pair {

--- a/storage/fs/export.go
+++ b/storage/fs/export.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // ExportPairs streams all pairs from the filesystem backend without building a

--- a/storage/fs/import.go
+++ b/storage/fs/import.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // ReplacePairs imports a streamed pair set into the filesystem backend.

--- a/storage/fs/index.go
+++ b/storage/fs/index.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // indexTimeFormat is the UTCTime format used in index.txt (yyMMddHHmmssZ).

--- a/storage/fs/layout.go
+++ b/storage/fs/layout.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // OwnershipProbe checks whether a filesystem directory is empty or already

--- a/storage/fs/layout_test.go
+++ b/storage/fs/layout_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
-	fs "github.com/kemsta/go-easyrsa/storage/fs"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	fs "github.com/kemsta/go-easyrsa/v2/storage/fs"
 )
 
 func TestOwnershipProbe_Empty(t *testing.T) {

--- a/storage/fs/storage.go
+++ b/storage/fs/storage.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // InitDirs creates the required subdirectory structure under pkiDir.

--- a/storage/fs/storage_test.go
+++ b/storage/fs/storage_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/pki"
-	fs "github.com/kemsta/go-easyrsa/storage/fs"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	fs "github.com/kemsta/go-easyrsa/v2/storage/fs"
 )
 
 // --- SerialProvider ---
@@ -146,7 +146,7 @@ func TestParseIndexLine_InvalidSerial(t *testing.T) {
 
 	_, err := db.Query(storage.IndexFilter{})
 	if err == nil {
-		t.Errorf("Query must return an error when index.txt contains a malformed serial; "+
+		t.Errorf("Query must return an error when index.txt contains a malformed serial; " +
 			"silently skipping corrupt lines makes revoked certs invisible to callers")
 	}
 }
@@ -326,8 +326,8 @@ func TestKeyStorage_GetBySerial_ReturnsStorageName_NotCN(t *testing.T) {
 	require.NoError(t, fs.InitDirs(dir))
 
 	p, err := pki.NewWithFS(dir, pki.Config{
-		NoPass: true,
-		DNMode: pki.DNModeOrg,
+		NoPass:       true,
+		DNMode:       pki.DNModeOrg,
 		SubjTemplate: pkix.Name{Organization: []string{"Acme Corp"}},
 	})
 	require.NoError(t, err)

--- a/storage/legacy/export.go
+++ b/storage/legacy/export.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // ExportPairs streams all legacy pairs without materializing their PEM payloads

--- a/storage/legacy/ownership_test.go
+++ b/storage/legacy/ownership_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
-	"github.com/kemsta/go-easyrsa/storage/legacy"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage/legacy"
 )
 
 func TestOwnershipProbe_Owned(t *testing.T) {

--- a/storage/legacy/storage.go
+++ b/storage/legacy/storage.go
@@ -18,9 +18,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
-	fsstore "github.com/kemsta/go-easyrsa/storage/fs"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	fsstore "github.com/kemsta/go-easyrsa/v2/storage/fs"
 )
 
 // KeyStorage implements storage.KeyStorage for the legacy v1 filesystem layout.

--- a/storage/legacy/storage_test.go
+++ b/storage/legacy/storage_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/storage"
-	"github.com/kemsta/go-easyrsa/storage/legacy"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage/legacy"
 )
 
 func TestKeyStorage_GetByNameAndGetLastByName(t *testing.T) {

--- a/storage/memory/export.go
+++ b/storage/memory/export.go
@@ -3,8 +3,8 @@ package memory
 import (
 	"sort"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // ExportPairs streams all in-memory pairs in ascending serial order.

--- a/storage/memory/import.go
+++ b/storage/memory/import.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // ReplacePairs imports a full pair stream while preserving history-by-name.

--- a/storage/memory/ownership_test.go
+++ b/storage/memory/ownership_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/pki"
-	"github.com/kemsta/go-easyrsa/storage"
-	"github.com/kemsta/go-easyrsa/storage/memory"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage/memory"
 )
 
 func TestOwnershipValidators(t *testing.T) {

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 // store holds all shared in-memory state.

--- a/storage/memory/storage_test.go
+++ b/storage/memory/storage_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/storage"
-	"github.com/kemsta/go-easyrsa/storage/memory"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage/memory"
 )
 
 func TestMemoryIndexDB_QueryReturnsIndependentSerials(t *testing.T) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kemsta/go-easyrsa/cert"
+	"github.com/kemsta/go-easyrsa/v2/cert"
 )
 
 // Sentinel errors returned by storage implementations.

--- a/storage/validation_test.go
+++ b/storage/validation_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kemsta/go-easyrsa/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage"
 )
 
 type fakeOwnershipValidator struct {

--- a/tests/e2e/ca_test.go
+++ b/tests/e2e/ca_test.go
@@ -5,8 +5,8 @@ package e2e
 import (
 	"testing"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/e2e/cert_test.go
+++ b/tests/e2e/cert_test.go
@@ -5,8 +5,8 @@ package e2e
 import (
 	"testing"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/e2e/csr_test.go
+++ b/tests/e2e/csr_test.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/e2e/export_test.go
+++ b/tests/e2e/export_test.go
@@ -5,8 +5,8 @@ package e2e
 import (
 	"testing"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/e2e/inspect_test.go
+++ b/tests/e2e/inspect_test.go
@@ -5,8 +5,8 @@ package e2e
 import (
 	"testing"
 
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/e2e/revoke_test.go
+++ b/tests/e2e/revoke_test.go
@@ -5,9 +5,9 @@ package e2e
 import (
 	"testing"
 
-	"github.com/kemsta/go-easyrsa/cert"
-	"github.com/kemsta/go-easyrsa/internal/testutil"
-	"github.com/kemsta/go-easyrsa/pki"
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/pki"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
## Summary
- switch the root module path to `github.com/kemsta/go-easyrsa/v2`
- update internal imports, README examples, and pkg.go.dev links to `/v2`
- update CLI submodules to the `/v2` module path as well

## Why
The repository already uses v2 releases, but the root module path still lacked the required `/v2` suffix for Go modules. Because of that, module tooling and pkg.go.dev kept treating `v1.0.2` as the latest valid version.

## Validation
- `go test ./...`
- `cd cmd/go-easyrsa-migrate && go test ./...`
- `cd cmd/go-easyrsa-legacy-cli && go test ./...`
