### PR TITLE
Fix standalone CLI module installation

### DIFF
--- a/cmd/go-easyrsa-legacy-cli/go.mod
+++ b/cmd/go-easyrsa-legacy-cli/go.mod
@@ -1,4 +1,4 @@
-module github.com/kemsta/go-easyrsa/v2/cmd/go-easyrsa-legacy-cli
+module github.com/kemsta/go-easyrsa/cmd/go-easyrsa-legacy-cli
 
 go 1.25.0
 
@@ -19,5 +19,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.7.0 // indirect
 )
-
-replace github.com/kemsta/go-easyrsa/v2 => ../..

--- a/cmd/go-easyrsa-legacy-cli/go.sum
+++ b/cmd/go-easyrsa-legacy-cli/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kemsta/go-easyrsa/v2 v2.1.0 h1:mOhQBSJvaE77ZRY85N3fOF9Xj860JFypb3JMKSJZ9gw=
+github.com/kemsta/go-easyrsa/v2 v2.1.0/go.mod h1:7tqfYC47f8xqVqWuhkyR2xMmNKHhDqIkonPTBx0di5w=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/cmd/go-easyrsa-migrate/go.mod
+++ b/cmd/go-easyrsa-migrate/go.mod
@@ -1,4 +1,4 @@
-module github.com/kemsta/go-easyrsa/v2/cmd/go-easyrsa-migrate
+module github.com/kemsta/go-easyrsa/cmd/go-easyrsa-migrate
 
 go 1.25.0
 
@@ -14,5 +14,3 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.7.0 // indirect
 )
-
-replace github.com/kemsta/go-easyrsa/v2 => ../..

--- a/cmd/go-easyrsa-migrate/go.sum
+++ b/cmd/go-easyrsa-migrate/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kemsta/go-easyrsa/v2 v2.1.0 h1:mOhQBSJvaE77ZRY85N3fOF9Xj860JFypb3JMKSJZ9gw=
+github.com/kemsta/go-easyrsa/v2 v2.1.0/go.mod h1:7tqfYC47f8xqVqWuhkyR2xMmNKHhDqIkonPTBx0di5w=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/cmd/go-easyrsa-migrate/legacy_fixture_test.go
+++ b/cmd/go-easyrsa-migrate/legacy_fixture_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	pkicrypto "github.com/kemsta/go-easyrsa/v2/crypto"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage/memory"
+)
+
+type legacyFixture struct {
+	Dir           string
+	CAPair        *cert.Pair
+	ClientOld     *cert.Pair
+	ClientCurrent *cert.Pair
+	ExpiredPair   *cert.Pair
+	RevokedPair   *cert.Pair
+	CRLPEM        []byte
+}
+
+func writeLegacyFixture(t *testing.T, dir string) legacyFixture {
+	t.Helper()
+
+	ks, cs, idx, sp, crl := memory.New()
+	p, err := pki.New(pki.Config{NoPass: true, SequentialSerial: true, KeyAlgo: pki.AlgoRSA, KeySize: 1024}, ks, cs, idx, sp, crl)
+	mustNoError(t, err)
+
+	caPair, err := p.BuildCA()
+	mustNoError(t, err)
+
+	clientOld, err := p.BuildClientFull("client1", pki.WithDays(365))
+	mustNoError(t, err)
+
+	clientCurrent, err := p.Renew("client1", pki.WithDays(730))
+	mustNoError(t, err)
+
+	expiredPair, err := p.BuildClientFull(
+		"expired1",
+		pki.WithNotBefore(time.Now().AddDate(0, 0, -10)),
+		pki.WithNotAfter(time.Now().AddDate(0, 0, -1)),
+	)
+	mustNoError(t, err)
+
+	revokedPair, err := p.BuildClientFull("revoked1", pki.WithDays(365))
+	mustNoError(t, err)
+	mustNoError(t, p.Revoke("revoked1", cert.ReasonKeyCompromise))
+	crlPEM, err := p.GenCRL()
+	mustNoError(t, err)
+
+	clientOld = clonePair(t, clientOld)
+	clientCurrent = clonePair(t, clientCurrent)
+	expiredPair = clonePair(t, expiredPair)
+	revokedPair = clonePair(t, revokedPair)
+	caPair = clonePair(t, caPair)
+
+	clientOld.KeyPEM = mustPKCS1PEM(t, clientOld.KeyPEM)
+	clientCurrent.KeyPEM = mustPKCS1PEM(t, clientCurrent.KeyPEM)
+
+	for _, pair := range []*cert.Pair{caPair, clientOld, clientCurrent, expiredPair, revokedPair} {
+		mustNoError(t, writeLegacyPair(dir, pair))
+	}
+	mustNoError(t, os.WriteFile(filepath.Join(dir, "crl.pem"), crlPEM, 0o644))
+
+	return legacyFixture{
+		Dir:           dir,
+		CAPair:        caPair,
+		ClientOld:     clientOld,
+		ClientCurrent: clientCurrent,
+		ExpiredPair:   expiredPair,
+		RevokedPair:   revokedPair,
+		CRLPEM:        crlPEM,
+	}
+}
+
+func writeLegacyPair(dir string, pair *cert.Pair) error {
+	serial, err := pair.Serial()
+	if err != nil {
+		return err
+	}
+	base := filepath.Join(dir, pair.Name)
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		return err
+	}
+	serialHex := serial.Text(16)
+	if err := os.WriteFile(filepath.Join(base, serialHex+".crt"), pair.CertPEM, 0o644); err != nil {
+		return err
+	}
+	if pair.KeyPEM != nil {
+		if err := os.WriteFile(filepath.Join(base, serialHex+".key"), pair.KeyPEM, 0o600); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mustPKCS1PEM(t *testing.T, keyPEM []byte) []byte {
+	t.Helper()
+	key, err := pkicrypto.UnmarshalPrivateKey(keyPEM, "")
+	mustNoError(t, err)
+	rsaKey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatalf("expected *rsa.PrivateKey, got %T", key)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rsaKey)})
+}
+
+func clonePair(t *testing.T, pair *cert.Pair) *cert.Pair {
+	t.Helper()
+	cp := &cert.Pair{Name: pair.Name}
+	if pair.CertPEM != nil {
+		cp.CertPEM = append([]byte(nil), pair.CertPEM...)
+	}
+	if pair.KeyPEM != nil {
+		cp.KeyPEM = append([]byte(nil), pair.KeyPEM...)
+	}
+	return cp
+}
+
+func mustSerial(t *testing.T, pair *cert.Pair) *big.Int {
+	t.Helper()
+	serial, err := pair.Serial()
+	mustNoError(t, err)
+	return new(big.Int).Set(serial)
+}
+
+func mustNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/go-easyrsa-migrate/main_test.go
+++ b/cmd/go-easyrsa-migrate/main_test.go
@@ -5,14 +5,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
 	"github.com/kemsta/go-easyrsa/v2/pki"
 	fsstore "github.com/kemsta/go-easyrsa/v2/storage/fs"
 )
 
 func TestCLI_MigratesLegacyToFS(t *testing.T) {
 	sourceDir := t.TempDir()
-	fixture := testutil.WriteLegacyFixture(t, sourceDir)
+	fixture := writeLegacyFixture(t, sourceDir)
 	targetDir := t.TempDir()
 
 	out, err := runCLI(t, "--from", sourceDir, "--to", targetDir)
@@ -32,16 +31,16 @@ func TestCLI_MigratesLegacyToFS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Serial: %v", err)
 	}
-	if serial.Cmp(testutil.MustSerial(t, fixture.ClientCurrent)) != 0 {
-		t.Fatalf("unexpected latest serial: got %s want %s", serial.Text(16), testutil.MustSerial(t, fixture.ClientCurrent).Text(16))
+	if serial.Cmp(mustSerial(t, fixture.ClientCurrent)) != 0 {
+		t.Fatalf("unexpected latest serial: got %s want %s", serial.Text(16), mustSerial(t, fixture.ClientCurrent).Text(16))
 	}
 }
 
 func TestCLI_RejectsNonEmptyTarget(t *testing.T) {
 	sourceDir := t.TempDir()
-	testutil.WriteLegacyFixture(t, sourceDir)
+	writeLegacyFixture(t, sourceDir)
 	targetDir := t.TempDir()
-	testutil.WriteLegacyFixture(t, targetDir)
+	writeLegacyFixture(t, targetDir)
 
 	_, err := runCLI(t, "--from", sourceDir, "--to", targetDir)
 	if err == nil {
@@ -51,7 +50,7 @@ func TestCLI_RejectsNonEmptyTarget(t *testing.T) {
 
 func TestCLI_RejectsUnknownFromType(t *testing.T) {
 	sourceDir := t.TempDir()
-	testutil.WriteLegacyFixture(t, sourceDir)
+	writeLegacyFixture(t, sourceDir)
 	targetDir := t.TempDir()
 
 	_, err := runCLI(t, "--from", sourceDir, "--to", targetDir, "--from-type", "wat")
@@ -62,7 +61,7 @@ func TestCLI_RejectsUnknownFromType(t *testing.T) {
 
 func TestCLI_RejectsUnknownToType(t *testing.T) {
 	sourceDir := t.TempDir()
-	testutil.WriteLegacyFixture(t, sourceDir)
+	writeLegacyFixture(t, sourceDir)
 	targetDir := t.TempDir()
 
 	_, err := runCLI(t, "--from", sourceDir, "--to", targetDir, "--to-type", "wat")
@@ -73,7 +72,7 @@ func TestCLI_RejectsUnknownToType(t *testing.T) {
 
 func TestCLI_RejectsSameSourceAndTarget(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteLegacyFixture(t, dir)
+	writeLegacyFixture(t, dir)
 
 	_, err := runCLI(t, "--from", dir, "--to", dir)
 	if err == nil {
@@ -83,7 +82,7 @@ func TestCLI_RejectsSameSourceAndTarget(t *testing.T) {
 
 func TestCLI_MigratesWithoutCRL(t *testing.T) {
 	sourceDir := t.TempDir()
-	testutil.WriteLegacyFixture(t, sourceDir)
+	writeLegacyFixture(t, sourceDir)
 	if err := os.Remove(filepath.Join(sourceDir, "crl.pem")); err != nil {
 		t.Fatalf("Remove crl.pem: %v", err)
 	}


### PR DESCRIPTION
## Summary
- restore standalone CLI module paths without `/v2`
- remove local `replace` directives so `go install ...@latest` works for published CLI modules
- stop CLI tests from importing root `internal/testutil`
- keep both CLI modules depending on `github.com/kemsta/go-easyrsa/v2`

## Validation
- `go test ./...`
- `cd cmd/go-easyrsa-migrate && go test ./...`
- `cd cmd/go-easyrsa-legacy-cli && go test ./...`
- verified standalone installs from a temp dir via:
  - `go install github.com/kemsta/go-easyrsa/cmd/go-easyrsa-migrate@cli-install-fix`
  - `go install github.com/kemsta/go-easyrsa/cmd/go-easyrsa-legacy-cli@cli-install-fix`
