### PR TITLE
test: raise coverage for public APIs

### DIFF
--- a/cert/csr_test.go
+++ b/cert/csr_test.go
@@ -1,0 +1,38 @@
+package cert_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	certpkg "github.com/kemsta/go-easyrsa/v2/cert"
+)
+
+func TestCSR_RequestAndSubject(t *testing.T) {
+	pk := newTestPKI(t)
+
+	csrPEM, err := pk.GenReq("client1")
+	require.NoError(t, err)
+
+	csr := &certpkg.CSR{Name: "client1", CSRPEM: csrPEM}
+	req, err := csr.Request()
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "client1", req.Subject.CommonName)
+
+	subject, err := csr.Subject()
+	require.NoError(t, err)
+	assert.Equal(t, req.Subject, subject)
+}
+
+func TestCSR_RequestAndSubjectErrors(t *testing.T) {
+	csr := &certpkg.CSR{Name: "broken", CSRPEM: []byte("not a csr")}
+
+	_, err := csr.Request()
+	assert.Error(t, err)
+
+	subject, err := csr.Subject()
+	assert.Error(t, err)
+	assert.Empty(t, subject.CommonName)
+}

--- a/cert/pair_test.go
+++ b/cert/pair_test.go
@@ -1,0 +1,128 @@
+package cert_test
+
+import (
+	"crypto"
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	certpkg "github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage/memory"
+)
+
+func newTestPKI(t *testing.T) *pki.PKI {
+	t.Helper()
+	ks, cs, idx, sp, crl := memory.New()
+	pk, err := pki.New(pki.Config{NoPass: true}, ks, cs, idx, sp, crl)
+	require.NoError(t, err)
+	return pk
+}
+
+func requirePrivateKey[T any](t *testing.T, key crypto.PrivateKey) T {
+	t.Helper()
+	typed, ok := key.(T)
+	require.Truef(t, ok, "expected private key type %T, got %T", *new(T), key)
+	return typed
+}
+
+func TestPair_PublicHelpersAcrossCertTypes(t *testing.T) {
+	pk := newTestPKI(t)
+
+	caPair, err := pk.BuildCA()
+	require.NoError(t, err)
+	clientPair, err := pk.BuildClientFull("client1")
+	require.NoError(t, err)
+	serverPair, err := pk.BuildServerFull("server1")
+	require.NoError(t, err)
+	serverClientPair, err := pk.BuildServerClientFull("sc1")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		pair     *certpkg.Pair
+		wantType certpkg.CertType
+		wantCA   bool
+	}{
+		{name: "ca", pair: caPair, wantType: certpkg.CertTypeCA, wantCA: true},
+		{name: "client", pair: clientPair, wantType: certpkg.CertTypeClient, wantCA: false},
+		{name: "server", pair: serverPair, wantType: certpkg.CertTypeServer, wantCA: false},
+		{name: "server-client", pair: serverClientPair, wantType: certpkg.CertTypeServerClient, wantCA: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			crt, err := tc.pair.Certificate()
+			require.NoError(t, err)
+			require.NotNil(t, crt)
+
+			serial, err := tc.pair.Serial()
+			require.NoError(t, err)
+			assert.Zero(t, serial.Cmp(crt.SerialNumber))
+
+			certType, err := tc.pair.CertType()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantType, certType)
+
+			isCA, err := tc.pair.IsCA()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantCA, isCA)
+
+			assert.True(t, tc.pair.HasKey())
+			key, err := tc.pair.PrivateKey()
+			require.NoError(t, err)
+			require.NotNil(t, key)
+			requirePrivateKey[crypto.Signer](t, key)
+		})
+	}
+}
+
+func TestPair_CertificateAndSerialErrors(t *testing.T) {
+	pair := &certpkg.Pair{Name: "broken", CertPEM: []byte("not a cert")}
+
+	_, err := pair.Certificate()
+	assert.Error(t, err)
+
+	_, err = pair.Serial()
+	assert.Error(t, err)
+
+	_, err = pair.CertType()
+	assert.Error(t, err)
+
+	_, err = pair.IsCA()
+	assert.Error(t, err)
+}
+
+func TestPair_PrivateKeyErrorsAndHasKey(t *testing.T) {
+	t.Run("missing key", func(t *testing.T) {
+		pair := &certpkg.Pair{Name: "nokey"}
+		assert.False(t, pair.HasKey())
+		_, err := pair.PrivateKey()
+		assert.Error(t, err)
+	})
+
+	t.Run("bad key pem", func(t *testing.T) {
+		pair := &certpkg.Pair{Name: "badkey", KeyPEM: []byte("not a key")}
+		assert.True(t, pair.HasKey())
+		_, err := pair.PrivateKey()
+		assert.Error(t, err)
+	})
+}
+
+func TestPair_CertTypeReturnsErrorForUnrecognizedEKU(t *testing.T) {
+	pk := newTestPKI(t)
+	_, err := pk.BuildCA()
+	require.NoError(t, err)
+
+	pair, err := pk.BuildClientFull("codesign", pki.WithCertModifier(func(c *x509.Certificate) {
+		c.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning}
+	}))
+	require.NoError(t, err)
+
+	certType, err := pair.CertType()
+	assert.Error(t, err)
+	assert.NotEqual(t, certpkg.CertTypeClient, certType)
+}

--- a/internal/testutil/easyrsa_test.go
+++ b/internal/testutil/easyrsa_test.go
@@ -1,0 +1,73 @@
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildHelperBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "main.go")
+	out := filepath.Join(dir, "helper")
+	if runtime.GOOS == "windows" {
+		out += ".exe"
+	}
+
+	const program = `package main
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+func main() {
+	fmt.Printf("args=%s\n", strings.Join(os.Args[1:], ","))
+	fmt.Printf("pki=%s\n", os.Getenv("EASYRSA_PKI"))
+	fmt.Printf("batch=%s\n", os.Getenv("EASYRSA_BATCH"))
+	if len(os.Args) > 0 && os.Args[len(os.Args)-1] == "fail" {
+		os.Exit(3)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(src, []byte(program), 0644))
+	cmd := exec.Command("go", "build", "-o", out, src)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "go build failed: %s", output)
+	return out
+}
+
+func TestModuleRoot_FindsRepositoryRoot(t *testing.T) {
+	root, err := moduleRoot()
+	require.NoError(t, err)
+	_, statErr := os.Stat(filepath.Join(root, "go.mod"))
+	require.NoError(t, statErr)
+}
+
+func TestNewRunnerRunE_UsesOverrideBinaryAndSetsEnv(t *testing.T) {
+	binary := buildHelperBinary(t)
+	t.Setenv("EASYRSA_BIN", binary)
+
+	runner := NewRunner(t, "/tmp/pki-dir")
+	out, err := runner.RunE("status")
+	require.NoError(t, err)
+	assert.Contains(t, out, "args=--batch,status")
+	assert.Contains(t, out, "pki=/tmp/pki-dir")
+	assert.Contains(t, out, "batch=1")
+}
+
+func TestRunnerRunE_ReturnsOutputOnFailure(t *testing.T) {
+	binary := buildHelperBinary(t)
+	t.Setenv("EASYRSA_BIN", binary)
+
+	runner := NewRunner(t, "/tmp/pki-dir")
+	out, err := runner.RunE("fail")
+	require.Error(t, err)
+	assert.Contains(t, out, "args=--batch,fail")
+}
+

--- a/internal/testutil/legacy_fixture_test.go
+++ b/internal/testutil/legacy_fixture_test.go
@@ -1,0 +1,69 @@
+package testutil
+
+import (
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kemsta/go-easyrsa/v2/cert"
+)
+
+func TestWriteLegacyFixture_WritesExpectedLegacyLayout(t *testing.T) {
+	dir := t.TempDir()
+	fixture := WriteLegacyFixture(t, dir)
+
+	assert.Equal(t, dir, fixture.Dir)
+	for _, tc := range []struct {
+		name    string
+		pair    *cert.Pair
+		wantKey bool
+	}{
+		{name: "ca", pair: fixture.CAPair, wantKey: true},
+		{name: "client-old", pair: fixture.ClientOld, wantKey: true},
+		{name: "client-current", pair: fixture.ClientCurrent, wantKey: true},
+		{name: "expired", pair: fixture.ExpiredPair, wantKey: true},
+		{name: "revoked", pair: fixture.RevokedPair, wantKey: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serialHex := MustSerial(t, tc.pair).Text(16)
+			certPath := filepath.Join(dir, tc.pair.Name, serialHex+".crt")
+			certPEM, err := os.ReadFile(certPath)
+			require.NoError(t, err)
+			assert.Equal(t, tc.pair.CertPEM, certPEM)
+
+			keyPath := filepath.Join(dir, tc.pair.Name, serialHex+".key")
+			keyPEM, err := os.ReadFile(keyPath)
+			if tc.wantKey {
+				require.NoError(t, err)
+				assert.Equal(t, tc.pair.KeyPEM, keyPEM)
+			} else {
+				assert.ErrorIs(t, err, os.ErrNotExist)
+			}
+		})
+	}
+
+	crlPEM, err := os.ReadFile(filepath.Join(dir, "crl.pem"))
+	require.NoError(t, err)
+	assert.Equal(t, fixture.CRLPEM, crlPEM)
+
+	for _, keyPEM := range [][]byte{fixture.ClientOld.KeyPEM, fixture.ClientCurrent.KeyPEM} {
+		block, _ := pem.Decode(keyPEM)
+		require.NotNil(t, block)
+		assert.Equal(t, "RSA PRIVATE KEY", block.Type)
+	}
+}
+
+func TestMustSerial_ReturnsIndependentCopy(t *testing.T) {
+	dir := t.TempDir()
+	fixture := WriteLegacyFixture(t, dir)
+
+	serial := MustSerial(t, fixture.ClientCurrent)
+	serial.SetInt64(999)
+	fresh := MustSerial(t, fixture.ClientCurrent)
+	assert.NotZero(t, fresh.Cmp(serial))
+}
+

--- a/pki/clean_test.go
+++ b/pki/clean_test.go
@@ -1,0 +1,71 @@
+package pki_test
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage/memory"
+)
+
+type cleaningKeyStorage struct {
+	storage.KeyStorage
+	cleaned map[string]bool
+	err     error
+}
+
+func mustSerial(t *testing.T, pair *cert.Pair) *big.Int {
+	t.Helper()
+	serial, err := pair.Serial()
+	require.NoError(t, err)
+	return new(big.Int).Set(serial)
+}
+
+func (c *cleaningKeyStorage) CleanOrphans(knownSerials map[string]bool) error {
+	c.cleaned = make(map[string]bool, len(knownSerials))
+	for k, v := range knownSerials {
+		c.cleaned[k] = v
+	}
+	return c.err
+}
+
+func TestClean_PassesKnownSerialsToCleaner(t *testing.T) {
+	innerKS, cs, idx, sp, crl := memory.New()
+	ks := &cleaningKeyStorage{KeyStorage: innerKS}
+	pk := mustNewPKI(t, pki.Config{NoPass: true, SequentialSerial: true}, ks, cs, idx, sp, crl)
+
+	caPair, err := pk.BuildCA()
+	require.NoError(t, err)
+	clientPair, err := pk.BuildClientFull("client1")
+	require.NoError(t, err)
+
+	require.NoError(t, pk.Clean())
+	assert.Equal(t, map[string]bool{
+		storage.HexSerial(mustSerial(t, caPair)):     true,
+		storage.HexSerial(mustSerial(t, clientPair)): true,
+	}, ks.cleaned)
+}
+
+func TestClean_NoOpWhenStorageDoesNotImplementCleaner(t *testing.T) {
+	pk := newTestPKI(pki.Config{NoPass: true})
+	buildTestCA(t, pk)
+	_, err := pk.BuildClientFull("client1")
+	require.NoError(t, err)
+	require.NoError(t, pk.Clean())
+}
+
+func TestClean_PropagatesCleanerError(t *testing.T) {
+	innerKS, cs, idx, sp, crl := memory.New()
+	ks := &cleaningKeyStorage{KeyStorage: innerKS, err: errors.New("clean failed")}
+	pk := mustNewPKI(t, pki.Config{NoPass: true}, ks, cs, idx, sp, crl)
+	buildTestCA(t, pk)
+
+	err := pk.Clean()
+	require.EqualError(t, err, "clean failed")
+}

--- a/pki/options_test.go
+++ b/pki/options_test.go
@@ -1,0 +1,143 @@
+package pki_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	pkicrypto "github.com/kemsta/go-easyrsa/v2/crypto"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+)
+
+func TestBuildClientFull_AppliesRichOptionSet(t *testing.T) {
+	p := newTestPKI(pki.Config{NoPass: true, DNMode: pki.DNModeOrg})
+	buildTestCA(t, p)
+
+	notBefore := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	notAfter := notBefore.Add(48 * time.Hour)
+	subject := pkix.Name{
+		CommonName:   "custom-cn",
+		Organization: []string{"Acme Corp"},
+		Country:      []string{"US"},
+	}
+
+	pair, err := p.BuildClientFull("client1",
+		pki.WithKeyAlgo(pki.AlgoECDSA),
+		pki.WithCurve(elliptic.P256()),
+		pki.WithNotBefore(notBefore),
+		pki.WithNotAfter(notAfter),
+		pki.WithSubject(subject),
+		pki.WithSubjectSerial("SUBJECT-42"),
+		pki.WithDNSNames("client.example.com"),
+		pki.WithIPAddresses(net.ParseIP("127.0.0.1")),
+		pki.WithEmailAddresses("client@example.com"),
+		pki.WithCertModifier(func(c *x509.Certificate) {
+			c.OCSPServer = []string{"http://ocsp.example.com"}
+		}),
+	)
+	require.NoError(t, err)
+
+	crt, err := pair.Certificate()
+	require.NoError(t, err)
+	assert.Equal(t, subject.CommonName, crt.Subject.CommonName)
+	assert.Equal(t, subject.Organization, crt.Subject.Organization)
+	assert.Equal(t, subject.Country, crt.Subject.Country)
+	assert.Equal(t, "SUBJECT-42", crt.Subject.SerialNumber)
+	assert.WithinDuration(t, notBefore, crt.NotBefore, time.Second)
+	assert.WithinDuration(t, notAfter, crt.NotAfter, time.Second)
+	assert.Equal(t, []string{"client.example.com"}, crt.DNSNames)
+	require.Len(t, crt.IPAddresses, 1)
+	assert.Equal(t, "127.0.0.1", crt.IPAddresses[0].String())
+	assert.Equal(t, []string{"client@example.com"}, crt.EmailAddresses)
+	assert.Equal(t, []string{"http://ocsp.example.com"}, crt.OCSPServer)
+
+	key, err := pair.PrivateKey()
+	require.NoError(t, err)
+	_, ok := key.(*ecdsa.PrivateKey)
+	assert.True(t, ok, "WithKeyAlgo/WithCurve must produce an ECDSA key")
+}
+
+func TestSignReq_AppliesCopyCSRExtensionsAndSubjectOverride(t *testing.T) {
+	p := newTestPKI(pki.Config{NoPass: true})
+	buildTestCA(t, p)
+
+	_, err := p.GenReq("client1",
+		pki.WithDNSNames("from-csr.example.com"),
+		pki.WithIPAddresses(net.ParseIP("127.0.0.2")),
+		pki.WithEmailAddresses("csr@example.com"),
+	)
+	require.NoError(t, err)
+
+	pair, err := p.SignReq("client1", cert.CertTypeClient,
+		pki.WithCopyCSRExtensions(),
+		pki.WithSubjectOverride(pkix.Name{
+			CommonName:   "override-cn",
+			Organization: []string{"Override Org"},
+		}),
+	)
+	require.NoError(t, err)
+
+	crt, err := pair.Certificate()
+	require.NoError(t, err)
+	assert.Equal(t, "override-cn", crt.Subject.CommonName)
+	assert.Equal(t, []string{"Override Org"}, crt.Subject.Organization)
+	assert.Equal(t, []string{"from-csr.example.com"}, crt.DNSNames)
+	require.Len(t, crt.IPAddresses, 1)
+	assert.Equal(t, "127.0.0.2", crt.IPAddresses[0].String())
+	assert.Equal(t, []string{"csr@example.com"}, crt.EmailAddresses)
+}
+
+func TestBuildCA_AppliesSubCAPathLenOption(t *testing.T) {
+	p := newTestPKI(pki.Config{NoPass: true})
+
+	pair, err := p.BuildCA(pki.WithSubCAPathLen(0))
+	require.NoError(t, err)
+	crt, err := pair.Certificate()
+	require.NoError(t, err)
+	assert.True(t, crt.MaxPathLenZero)
+	assert.Zero(t, crt.MaxPathLen)
+}
+
+func TestBuildClientFull_PassphraseAndNoPassOverrides(t *testing.T) {
+	t.Run("WithPassphrase encrypts generated key", func(t *testing.T) {
+		p := newTestPKI(pki.Config{NoPass: true})
+		buildTestCA(t, p)
+
+		pair, err := p.BuildClientFull("encrypted-client",
+			pki.WithKeyAlgo(pki.AlgoRSA),
+			pki.WithKeySize(1024),
+			pki.WithCN("encrypted-cn"),
+			pki.WithDays(5),
+			pki.WithPassphrase("secret"),
+		)
+		require.NoError(t, err)
+
+		_, err = pair.PrivateKey()
+		assert.Error(t, err, "Pair.PrivateKey expects plaintext PKCS8 and must fail for encrypted keys")
+		key, err := pkicrypto.UnmarshalPrivateKey(pair.KeyPEM, "secret")
+		require.NoError(t, err)
+		require.NotNil(t, key)
+
+		crt, err := pair.Certificate()
+		require.NoError(t, err)
+		assert.Equal(t, "encrypted-cn", crt.Subject.CommonName)
+	})
+
+	t.Run("WithNoPass overrides encrypted default", func(t *testing.T) {
+		p := newTestPKI(pki.Config{NoPass: false, CAPassphrase: "ca-pass"})
+		buildTestCA(t, p, pki.WithPassphrase("ca-pass"))
+
+		pair, err := p.BuildClientFull("plain-client", pki.WithNoPass())
+		require.NoError(t, err)
+		_, err = pair.PrivateKey()
+		require.NoError(t, err)
+	})
+}

--- a/storage/fs/export_test.go
+++ b/storage/fs/export_test.go
@@ -1,0 +1,83 @@
+package fs_test
+
+import (
+	"crypto/x509/pkix"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	fs "github.com/kemsta/go-easyrsa/v2/storage/fs"
+)
+
+func TestFSExportPairs_SortsBySerialAndUsesStorageNames(t *testing.T) {
+	dir := t.TempDir()
+	pk, err := pki.NewWithFS(dir, pki.Config{
+		NoPass:           true,
+		SequentialSerial: true,
+		DNMode:           pki.DNModeOrg,
+		SubjTemplate:     pkix.Name{Organization: []string{"Acme Corp"}},
+	})
+	require.NoError(t, err)
+	_, err = pk.BuildCA()
+	require.NoError(t, err)
+	serverPair, err := pk.BuildServerFull("server1", pki.WithSubjectOverride(pkix.Name{
+		CommonName:   "VPN Server",
+		Organization: []string{"Acme Corp"},
+	}))
+	require.NoError(t, err)
+	clientPair, err := pk.BuildClientFull("client2")
+	require.NoError(t, err)
+
+	ks := fs.NewKeyStorage(dir, "ca")
+	exported := collectExportedPairs(t, ks)
+	require.Len(t, exported, 3)
+	assert.Equal(t, []string{"ca", "server1", "client2"}, []string{exported[0].Name, exported[1].Name, exported[2].Name})
+	assert.Zero(t, mustSerial(t, exported[1]).Cmp(mustSerial(t, serverPair)))
+	assert.Zero(t, mustSerial(t, exported[2]).Cmp(mustSerial(t, clientPair)))
+}
+
+func TestFSExportPairs_FallsBackToNamedPairsWhenSerialIndexMissing(t *testing.T) {
+	sourceDir, pk := newFSPKI(t)
+	caPair, err := pk.BuildCA()
+	require.NoError(t, err)
+	clientPair, err := pk.BuildClientFull("client1")
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "issued"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "private"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ca.crt"), caPair.CertPEM, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "private", "ca.key"), caPair.KeyPEM, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "issued", "client1.crt"), clientPair.CertPEM, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "private", "client1.key"), clientPair.KeyPEM, 0600))
+	_ = sourceDir
+
+	ks := fs.NewKeyStorage(dir, "ca")
+	exported := collectExportedPairs(t, ks)
+	require.Len(t, exported, 2)
+	assert.ElementsMatch(t, []string{"ca", "client1"}, []string{exported[0].Name, exported[1].Name})
+}
+
+func TestFSExportPairs_StopsOnYieldError(t *testing.T) {
+	dir, pk := newFSPKI(t)
+	_, err := pk.BuildCA()
+	require.NoError(t, err)
+	_, err = pk.BuildClientFull("client1")
+	require.NoError(t, err)
+
+	ks := fs.NewKeyStorage(dir, "ca")
+	wantErr := errors.New("stop")
+	calls := 0
+	err = ks.ExportPairs(func(*cert.Pair) error {
+		calls++
+		return wantErr
+	})
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, calls)
+}

--- a/storage/fs/import_test.go
+++ b/storage/fs/import_test.go
@@ -1,0 +1,90 @@
+package fs_test
+
+import (
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/pki"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	fs "github.com/kemsta/go-easyrsa/v2/storage/fs"
+)
+
+func TestFSReplacePairs_ImportsStreamAndPreservesLatestNamedCert(t *testing.T) {
+	sourceDir, sourcePK := newFSPKI(t)
+	_, err := sourcePK.BuildCA()
+	require.NoError(t, err)
+	oldPair, err := sourcePK.BuildClientFull("client1", pki.WithDays(365))
+	require.NoError(t, err)
+	newPair, err := sourcePK.Renew("client1", pki.WithDays(730))
+	require.NoError(t, err)
+
+	sourceKS := fs.NewKeyStorage(sourceDir, "ca")
+	sourcePairs := collectExportedPairs(t, sourceKS)
+	require.Len(t, sourcePairs, 3)
+
+	targetDir := t.TempDir()
+	require.NoError(t, fs.InitDirs(targetDir))
+	targetKS := fs.NewKeyStorage(targetDir, "ca")
+	require.NoError(t, targetKS.ReplacePairs(func(yield func(*cert.Pair) error) error {
+		for _, pair := range sourcePairs {
+			if err := yield(pair); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	last, err := targetKS.GetLastByName("client1")
+	require.NoError(t, err)
+	assert.Zero(t, mustSerial(t, last).Cmp(mustSerial(t, newPair)))
+
+	byOldSerial, err := targetKS.GetBySerial(mustSerial(t, oldPair))
+	require.NoError(t, err)
+	assert.Equal(t, "client1", byOldSerial.Name)
+	byNewSerial, err := targetKS.GetBySerial(mustSerial(t, newPair))
+	require.NoError(t, err)
+	assert.Equal(t, "client1", byNewSerial.Name)
+
+	all, err := targetKS.GetAll()
+	require.NoError(t, err)
+	assert.Equal(t, pairIDs(t, sourcePairs), pairIDs(t, all))
+}
+
+func TestFSSetNext_ValidationAndPersistence(t *testing.T) {
+	dir, _ := newFSPKI(t)
+	sp := fs.NewSerialProvider(dir)
+
+	assert.Error(t, sp.SetNext(nil))
+	assert.Error(t, sp.SetNext(big.NewInt(0)))
+
+	require.NoError(t, sp.SetNext(big.NewInt(80)))
+	next, err := sp.Next()
+	require.NoError(t, err)
+	assert.Zero(t, next.Cmp(big.NewInt(80)))
+
+	sp2 := fs.NewSerialProvider(dir)
+	next, err = sp2.Next()
+	require.NoError(t, err)
+	assert.Zero(t, next.Cmp(big.NewInt(81)))
+}
+
+func TestFSReplaceAll_HappyPath(t *testing.T) {
+	dir, _ := newFSPKI(t)
+	db := fs.NewIndexDB(dir)
+	entries := []storage.IndexEntry{{
+		Status: storage.StatusValid,
+		Serial: big.NewInt(7),
+		Subject: pkix.Name{CommonName: "client1"},
+	}}
+	require.NoError(t, db.ReplaceAll(entries))
+
+	got, err := db.Query(storage.IndexFilter{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Zero(t, got[0].Serial.Cmp(big.NewInt(7)))
+}

--- a/storage/fs/storage_test.go
+++ b/storage/fs/storage_test.go
@@ -2,22 +2,21 @@ package fs_test
 
 import (
 	"crypto/x509/pkix"
-	"math/big"
-	"os"
-	"path/filepath"
-	"reflect"
-	"strings"
-	"sync"
-	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/kemsta/go-easyrsa/v2/cert"
 	"github.com/kemsta/go-easyrsa/v2/pki"
 	"github.com/kemsta/go-easyrsa/v2/storage"
 	fs "github.com/kemsta/go-easyrsa/v2/storage/fs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
 )
 
 // --- SerialProvider ---
@@ -353,4 +352,216 @@ func TestKeyStorage_GetBySerial_ReturnsStorageName_NotCN(t *testing.T) {
 
 	assert.Equal(t, "server1", got.Name,
 		"GetBySerial must return the storage entity name ('server1'), not the Subject CN ('VPN Server')")
+}
+func newFSPKI(t *testing.T) (string, *pki.PKI) {
+	t.Helper()
+	dir := t.TempDir()
+	pk, err := pki.NewWithFS(dir, pki.Config{NoPass: true, SequentialSerial: true})
+	require.NoError(t, err)
+	return dir, pk
+}
+
+func mustSerial(t *testing.T, pair *cert.Pair) *big.Int {
+	t.Helper()
+	serial, err := pair.Serial()
+	require.NoError(t, err)
+	return new(big.Int).Set(serial)
+}
+
+func collectExportedPairs(t *testing.T, exporter storage.PairExporter) []*cert.Pair {
+	t.Helper()
+	var pairs []*cert.Pair
+	err := exporter.ExportPairs(func(pair *cert.Pair) error {
+		cp := &cert.Pair{Name: pair.Name}
+		if pair.CertPEM != nil {
+			cp.CertPEM = append([]byte(nil), pair.CertPEM...)
+		}
+		if pair.KeyPEM != nil {
+			cp.KeyPEM = append([]byte(nil), pair.KeyPEM...)
+		}
+		pairs = append(pairs, cp)
+		return nil
+	})
+	require.NoError(t, err)
+	return pairs
+}
+
+func pairIDs(t *testing.T, pairs []*cert.Pair) []string {
+	t.Helper()
+	ids := make([]string, 0, len(pairs))
+	for _, pair := range pairs {
+		serial, err := pair.Serial()
+		require.NoError(t, err)
+		ids = append(ids, pair.Name+":"+storage.HexSerial(serial))
+	}
+	sort.Strings(ids)
+	return ids
+}
+func TestKeyStorage_PublicCRUDAndDeleteSemantics(t *testing.T) {
+	dir, pk := newFSPKI(t)
+	_, err := pk.BuildCA()
+	require.NoError(t, err)
+	client1, err := pk.BuildClientFull("client1")
+	require.NoError(t, err)
+	client2, err := pk.BuildClientFull("client2")
+	require.NoError(t, err)
+
+	ks := fs.NewKeyStorage(dir, "ca")
+
+	pairs, err := ks.GetByName("client1")
+	require.NoError(t, err)
+	require.Len(t, pairs, 1)
+	assert.Equal(t, "client1", pairs[0].Name)
+
+	last, err := ks.GetLastByName("client1")
+	require.NoError(t, err)
+	assert.Equal(t, "client1", last.Name)
+
+	bySerial, err := ks.GetBySerial(mustSerial(t, client1))
+	require.NoError(t, err)
+	assert.Equal(t, "client1", bySerial.Name)
+
+	all, err := ks.GetAll()
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	assert.ElementsMatch(t, []string{"ca", "client1", "client2"}, []string{all[0].Name, all[1].Name, all[2].Name})
+
+	serial2 := mustSerial(t, client2)
+	serialHex2 := storage.HexSerial(serial2)
+	require.NoError(t, ks.DeleteBySerial(serial2))
+	_, err = ks.GetBySerial(serial2)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	_, err = os.Stat(filepath.Join(dir, "certs_by_serial", serialHex2+".pem"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(dir, "certs_by_serial", serialHex2+".name"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = ks.GetLastByName("client2")
+	require.NoError(t, err, "DeleteBySerial must not remove the named certificate view")
+
+	serial1 := mustSerial(t, client1)
+	require.NoError(t, ks.DeleteByName("client1"))
+	_, err = ks.GetByName("client1")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	_, err = ks.GetBySerial(serial1)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	_, err = os.Stat(filepath.Join(dir, "issued", "client1.crt"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(dir, "private", "client1.key"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestKeyStorage_GetLastByNameFallsBackToRevokedStorage(t *testing.T) {
+	dir, pk := newFSPKI(t)
+	_, err := pk.BuildCA()
+	require.NoError(t, err)
+	client, err := pk.BuildClientFull("client1")
+	require.NoError(t, err)
+	require.NoError(t, pk.Revoke("client1", cert.ReasonKeyCompromise))
+
+	ks := fs.NewKeyStorage(dir, "ca")
+	pair, err := ks.GetLastByName("client1")
+	require.NoError(t, err)
+	assert.Equal(t, "client1", pair.Name)
+	assert.NotEmpty(t, pair.CertPEM)
+	assert.NotEmpty(t, pair.KeyPEM)
+	assert.Zero(t, mustSerial(t, pair).Cmp(mustSerial(t, client)))
+}
+
+func TestKeyStorage_CleanOrphansRemovesUnknownCertArtifacts(t *testing.T) {
+	dir, pk := newFSPKI(t)
+	caPair, err := pk.BuildCA()
+	require.NoError(t, err)
+	client1, err := pk.BuildClientFull("client1")
+	require.NoError(t, err)
+	client2, err := pk.BuildClientFull("client2")
+	require.NoError(t, err)
+
+	knownSerials := map[string]bool{
+		storage.HexSerial(mustSerial(t, caPair)):  true,
+		storage.HexSerial(mustSerial(t, client1)): true,
+	}
+
+	ks := fs.NewKeyStorage(dir, "ca")
+	require.NoError(t, ks.CleanOrphans(knownSerials))
+
+	serialHex2 := storage.HexSerial(mustSerial(t, client2))
+	_, err = os.Stat(filepath.Join(dir, "certs_by_serial", serialHex2+".pem"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(dir, "certs_by_serial", serialHex2+".name"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(dir, "issued", "client2.crt"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(dir, "private", "client2.key"))
+	require.NoError(t, err, "CleanOrphans must preserve private keys because they may be shared with a valid renewal")
+
+	_, err = ks.GetBySerial(mustSerial(t, client1))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, "ca.crt"))
+	require.NoError(t, err)
+}
+
+func TestCSRStorage_PublicCRUD(t *testing.T) {
+	dir, _ := newFSPKI(t)
+	cs := fs.NewCSRStorage(dir)
+
+	require.NoError(t, cs.PutCSR("client1", []byte("csr-1")))
+	require.NoError(t, cs.PutCSR("client2", []byte("csr-2")))
+
+	csr, err := cs.GetCSR("client1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("csr-1"), csr)
+
+	names, err := cs.ListCSRs()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"client1", "client2"}, names)
+
+	require.NoError(t, cs.DeleteCSR("client1"))
+	_, err = cs.GetCSR("client1")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	assert.ErrorIs(t, cs.DeleteCSR("client1"), storage.ErrNotFound)
+}
+
+func TestSerialProvider_SetNextPersistsAcrossInstances(t *testing.T) {
+	dir, _ := newFSPKI(t)
+	sp := fs.NewSerialProvider(dir)
+
+	assert.Error(t, sp.SetNext(nil))
+	assert.Error(t, sp.SetNext(big.NewInt(0)))
+
+	require.NoError(t, sp.SetNext(big.NewInt(42)))
+	next, err := sp.Next()
+	require.NoError(t, err)
+	assert.Zero(t, next.Cmp(big.NewInt(42)))
+
+	sp2 := fs.NewSerialProvider(dir)
+	next, err = sp2.Next()
+	require.NoError(t, err)
+	assert.Zero(t, next.Cmp(big.NewInt(43)))
+}
+
+func TestCRLHolder_PublicBehavior(t *testing.T) {
+	dir, pk := newFSPKI(t)
+	ch := fs.NewCRLHolder(dir)
+
+	list, err := ch.Get()
+	require.NoError(t, err)
+	assert.Empty(t, list.RevokedCertificateEntries)
+
+	_, err = pk.BuildCA()
+	require.NoError(t, err)
+	_, err = pk.BuildClientFull("client1")
+	require.NoError(t, err)
+	require.NoError(t, pk.Revoke("client1", cert.ReasonKeyCompromise))
+	crlPEM, err := pk.GenCRL()
+	require.NoError(t, err)
+
+	require.NoError(t, ch.Put(crlPEM))
+	list, err = ch.Get()
+	require.NoError(t, err)
+	require.Len(t, list.RevokedCertificateEntries, 1)
+
+	require.NoError(t, ch.Delete())
+	list, err = ch.Get()
+	require.NoError(t, err)
+	assert.Empty(t, list.RevokedCertificateEntries)
 }

--- a/storage/legacy/export_test.go
+++ b/storage/legacy/export_test.go
@@ -1,0 +1,52 @@
+package legacy_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage/legacy"
+)
+
+func TestLegacyExportPairs_StreamsAllPairsInLegacyOrder(t *testing.T) {
+	dir := t.TempDir()
+	fixture := testutil.WriteLegacyFixture(t, dir)
+	ks := legacy.NewKeyStorage(dir, "ca")
+
+	var got []string
+	err := ks.ExportPairs(func(pair *cert.Pair) error {
+		serial, err := pair.Serial()
+		require.NoError(t, err)
+		got = append(got, pair.Name+":"+storage.HexSerial(serial))
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"ca:" + storage.HexSerial(testutil.MustSerial(t, fixture.CAPair)),
+		"client1:" + storage.HexSerial(testutil.MustSerial(t, fixture.ClientOld)),
+		"client1:" + storage.HexSerial(testutil.MustSerial(t, fixture.ClientCurrent)),
+		"expired1:" + storage.HexSerial(testutil.MustSerial(t, fixture.ExpiredPair)),
+		"revoked1:" + storage.HexSerial(testutil.MustSerial(t, fixture.RevokedPair)),
+	}, got)
+}
+
+func TestLegacyExportPairs_StopsOnYieldError(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteLegacyFixture(t, dir)
+	ks := legacy.NewKeyStorage(dir, "ca")
+
+	wantErr := errors.New("stop")
+	calls := 0
+	err := ks.ExportPairs(func(*cert.Pair) error {
+		calls++
+		return wantErr
+	})
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, calls)
+}

--- a/storage/legacy/storage_test.go
+++ b/storage/legacy/storage_test.go
@@ -1,17 +1,15 @@
 package legacy_test
 
 import (
+	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage/legacy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/kemsta/go-easyrsa/v2/internal/testutil"
-	"github.com/kemsta/go-easyrsa/v2/storage"
-	"github.com/kemsta/go-easyrsa/v2/storage/legacy"
 )
 
 func TestKeyStorage_GetByNameAndGetLastByName(t *testing.T) {
@@ -119,4 +117,52 @@ func TestReadOnlyComponentsRejectWrites(t *testing.T) {
 	assert.ErrorIs(t, crl.Put([]byte("pem")), storage.ErrReadOnly)
 	_, err = crl.Get()
 	require.NoError(t, err)
+}
+func TestLegacyKeyStorage_GetAllIncludesHistory(t *testing.T) {
+	dir := t.TempDir()
+	fixture := testutil.WriteLegacyFixture(t, dir)
+	ks := legacy.NewKeyStorage(dir, "ca")
+
+	pairs, err := ks.GetAll()
+	require.NoError(t, err)
+	require.Len(t, pairs, 5)
+
+	ids := make([]string, 0, len(pairs))
+	for _, pair := range pairs {
+		serial, err := pair.Serial()
+		require.NoError(t, err)
+		ids = append(ids, pair.Name+":"+storage.HexSerial(serial))
+	}
+	assert.ElementsMatch(t, []string{
+		"ca:" + storage.HexSerial(testutil.MustSerial(t, fixture.CAPair)),
+		"client1:" + storage.HexSerial(testutil.MustSerial(t, fixture.ClientOld)),
+		"client1:" + storage.HexSerial(testutil.MustSerial(t, fixture.ClientCurrent)),
+		"expired1:" + storage.HexSerial(testutil.MustSerial(t, fixture.ExpiredPair)),
+		"revoked1:" + storage.HexSerial(testutil.MustSerial(t, fixture.RevokedPair)),
+	}, ids)
+}
+
+func TestLegacyKeyStorage_GetByNameRejectsUnsafeNames(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteLegacyFixture(t, dir)
+	ks := legacy.NewKeyStorage(dir, "ca")
+
+	for _, name := range []string{"", ".", "../client1", `..\\client1`, "client/1", "client\\1"} {
+		_, err := ks.GetByName(name)
+		assert.ErrorIsf(t, err, storage.ErrNotFound, "name=%q", name)
+	}
+}
+
+func TestLegacyIndexDB_QueryByName(t *testing.T) {
+	dir := t.TempDir()
+	fixture := testutil.WriteLegacyFixture(t, dir)
+	ks := legacy.NewKeyStorage(dir, "ca")
+	crl := legacy.NewCRLHolder(dir)
+	db := legacy.NewIndexDB(ks, crl)
+
+	entries, err := db.Query(storage.IndexFilter{Name: "revoked1"})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, storage.StatusRevoked, entries[0].Status)
+	assert.Zero(t, entries[0].Serial.Cmp(testutil.MustSerial(t, fixture.RevokedPair)))
 }

--- a/storage/memory/export_test.go
+++ b/storage/memory/export_test.go
@@ -1,0 +1,65 @@
+package memory_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+)
+
+func TestMemoryExportPairs_SortsBySerialAndCopiesPayloads(t *testing.T) {
+	ks, _, _, _, _, pk := newMemoryPKI(t)
+
+	_, err := pk.BuildCA()
+	require.NoError(t, err)
+	pair2, err := pk.BuildClientFull("client2")
+	require.NoError(t, err)
+	pair1, err := pk.BuildClientFull("client1")
+	require.NoError(t, err)
+
+	exported := collectExportedPairs(t, ks)
+	require.Len(t, exported, 3)
+
+	assert.Equal(t, []string{
+		"ca:" + storage.HexSerial(mustSerial(t, exported[0])),
+		"client2:" + storage.HexSerial(mustSerial(t, exported[1])),
+		"client1:" + storage.HexSerial(mustSerial(t, exported[2])),
+	}, []string{
+		exported[0].Name + ":" + storage.HexSerial(mustSerial(t, exported[0])),
+		exported[1].Name + ":" + storage.HexSerial(mustSerial(t, exported[1])),
+		exported[2].Name + ":" + storage.HexSerial(mustSerial(t, exported[2])),
+	})
+
+	original, err := ks.GetBySerial(mustSerial(t, pair1))
+	require.NoError(t, err)
+	exported[2].KeyPEM[0] ^= 0xFF
+	exported[2].CertPEM[0] ^= 0xFF
+	again, err := ks.GetBySerial(mustSerial(t, pair1))
+	require.NoError(t, err)
+	assert.Equal(t, original.KeyPEM, again.KeyPEM)
+	assert.Equal(t, original.CertPEM, again.CertPEM)
+
+	_ = pair2 // keeps intent explicit: exported order is based on serial, not lexical name order.
+}
+
+func TestMemoryExportPairs_StopsOnYieldError(t *testing.T) {
+	ks, _, _, _, _, pk := newMemoryPKI(t)
+
+	_, err := pk.BuildCA()
+	require.NoError(t, err)
+	_, err = pk.BuildClientFull("client1")
+	require.NoError(t, err)
+
+	wantErr := errors.New("stop")
+	calls := 0
+	err = ks.ExportPairs(func(*cert.Pair) error {
+		calls++
+		return wantErr
+	})
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, calls)
+}

--- a/storage/memory/import_test.go
+++ b/storage/memory/import_test.go
@@ -1,0 +1,79 @@
+package memory_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/storage"
+	"github.com/kemsta/go-easyrsa/v2/storage/memory"
+)
+
+func TestMemoryReplacePairs_ReplacesStateAndClonesInput(t *testing.T) {
+	srcKS, _, _, _, _, srcPK := newMemoryPKI(t)
+	_, err := srcPK.BuildCA()
+	require.NoError(t, err)
+	pair1, err := srcPK.BuildClientFull("client1")
+	require.NoError(t, err)
+	pair2, err := srcPK.BuildClientFull("client2")
+	require.NoError(t, err)
+	sourcePairs := collectExportedPairs(t, srcKS)
+
+	dstKS, _, _, _, _ := memory.New()
+	require.NoError(t, dstKS.ReplacePairs(func(yield func(*cert.Pair) error) error {
+		for i, pair := range sourcePairs {
+			if i == 1 {
+				require.NoError(t, yield(nil))
+			}
+			if err := yield(pair); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	sourcePairs[0].CertPEM[0] ^= 0xFF
+	sourcePairs[0].KeyPEM[0] ^= 0xFF
+
+	gotPairs := collectExportedPairs(t, dstKS)
+	assert.Equal(t, pairIDs(t, collectExportedPairs(t, srcKS)), pairIDs(t, gotPairs))
+
+	got1, err := dstKS.GetBySerial(mustSerial(t, pair1))
+	require.NoError(t, err)
+	assert.Equal(t, pair1.Name, got1.Name)
+
+	got2, err := dstKS.GetBySerial(mustSerial(t, pair2))
+	require.NoError(t, err)
+	assert.Equal(t, pair2.Name, got2.Name)
+}
+
+func TestMemoryReplaceAllAndSetNext_CloneInputs(t *testing.T) {
+	_, _, idx, sp, _ := memory.New()
+
+	serial := big.NewInt(7)
+	entries := []storage.IndexEntry{{
+		Status:    storage.StatusValid,
+		Serial:    serial,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+		Subject:   pkixName("client1"),
+	}}
+	require.NoError(t, idx.ReplaceAll(entries))
+	serial.SetInt64(99)
+	entries[0].Serial.SetInt64(100)
+
+	got, err := idx.Query(storage.IndexFilter{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Zero(t, got[0].Serial.Cmp(big.NewInt(7)))
+
+	next := big.NewInt(50)
+	require.NoError(t, sp.SetNext(next))
+	next.SetInt64(1)
+	gotNext, err := sp.Next()
+	require.NoError(t, err)
+	assert.Zero(t, gotNext.Cmp(big.NewInt(50)))
+}

--- a/storage/memory/storage_test.go
+++ b/storage/memory/storage_test.go
@@ -1,16 +1,17 @@
 package memory_test
 
 import (
-	"math/big"
-	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
+	"crypto/x509/pkix"
 	"github.com/kemsta/go-easyrsa/v2/cert"
+	"github.com/kemsta/go-easyrsa/v2/pki"
 	"github.com/kemsta/go-easyrsa/v2/storage"
 	"github.com/kemsta/go-easyrsa/v2/storage/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"sort"
+	"testing"
+	"time"
 )
 
 func TestMemoryIndexDB_QueryReturnsIndependentSerials(t *testing.T) {
@@ -98,3 +99,235 @@ func TestMemoryKeyStorage_KeyOnlyPutDoesNotHideExistingCert(t *testing.T) {
 			"Key-only Puts must update the existing pair's key in place, "+
 			"not append a new key-only entry.")
 }
+func newMemoryPKI(t *testing.T) (*memory.KeyStorage, *memory.CSRStorage, *memory.IndexDB, *memory.SerialProvider, *memory.CRLHolder, *pki.PKI) {
+	t.Helper()
+	ks, cs, idx, sp, crl := memory.New()
+	pk, err := pki.New(pki.Config{NoPass: true, SequentialSerial: true}, ks, cs, idx, sp, crl)
+	require.NoError(t, err)
+	return ks, cs, idx, sp, crl, pk
+}
+
+func mustSerial(t *testing.T, pair *cert.Pair) *big.Int {
+	t.Helper()
+	serial, err := pair.Serial()
+	require.NoError(t, err)
+	return new(big.Int).Set(serial)
+}
+
+func collectExportedPairs(t *testing.T, exporter storage.PairExporter) []*cert.Pair {
+	t.Helper()
+	var pairs []*cert.Pair
+	err := exporter.ExportPairs(func(pair *cert.Pair) error {
+		cp := &cert.Pair{Name: pair.Name}
+		if pair.CertPEM != nil {
+			cp.CertPEM = append([]byte(nil), pair.CertPEM...)
+		}
+		if pair.KeyPEM != nil {
+			cp.KeyPEM = append([]byte(nil), pair.KeyPEM...)
+		}
+		pairs = append(pairs, cp)
+		return nil
+	})
+	require.NoError(t, err)
+	return pairs
+}
+
+func pairIDs(t *testing.T, pairs []*cert.Pair) []string {
+	t.Helper()
+	ids := make([]string, 0, len(pairs))
+	for _, pair := range pairs {
+		serial, err := pair.Serial()
+		require.NoError(t, err)
+		ids = append(ids, pair.Name+":"+storage.HexSerial(serial))
+	}
+	sort.Strings(ids)
+	return ids
+}
+func TestMemoryKeyStorage_PublicCRUDAndNotFound(t *testing.T) {
+	ks, _, _, _, _, pk := newMemoryPKI(t)
+
+	_, err := pk.BuildCA()
+	require.NoError(t, err)
+	client1, err := pk.BuildClientFull("client1")
+	require.NoError(t, err)
+	client2, err := pk.BuildClientFull("client2")
+	require.NoError(t, err)
+
+	pairs, err := ks.GetByName("client1")
+	require.NoError(t, err)
+	require.Len(t, pairs, 1)
+	assert.Equal(t, "client1", pairs[0].Name)
+
+	pairBySerial, err := ks.GetBySerial(mustSerial(t, client1))
+	require.NoError(t, err)
+	assert.Equal(t, client1.Name, pairBySerial.Name)
+
+	all, err := ks.GetAll()
+	require.NoError(t, err)
+	assert.ElementsMatch(t,
+		[]string{"ca", "client1", "client2"},
+		[]string{all[0].Name, all[1].Name, all[2].Name},
+	)
+
+	require.NoError(t, ks.DeleteBySerial(mustSerial(t, client2)))
+	_, err = ks.GetBySerial(mustSerial(t, client2))
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	_, err = ks.GetByName("client2")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+
+	require.NoError(t, ks.DeleteByName("client1"))
+	_, err = ks.GetByName("client1")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	_, err = ks.GetBySerial(mustSerial(t, client1))
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+
+	_, err = ks.GetByName("missing")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	_, err = ks.GetLastByName("missing")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	_, err = ks.GetBySerial(big.NewInt(999))
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	assert.ErrorIs(t, ks.DeleteByName("missing"), storage.ErrNotFound)
+	assert.ErrorIs(t, ks.DeleteBySerial(big.NewInt(999)), storage.ErrNotFound)
+}
+
+func TestMemoryCSRStorage_PublicCRUD(t *testing.T) {
+	_, cs, _, _, _, _ := newMemoryPKI(t)
+
+	empty, err := cs.Empty()
+	require.NoError(t, err)
+	assert.True(t, empty)
+
+	require.NoError(t, cs.PutCSR("client1", []byte("csr-1")))
+	require.NoError(t, cs.PutCSR("client2", []byte("csr-2")))
+
+	csr, err := cs.GetCSR("client1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("csr-1"), csr)
+
+	names, err := cs.ListCSRs()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"client1", "client2"}, names)
+
+	require.NoError(t, cs.DeleteCSR("client1"))
+	_, err = cs.GetCSR("client1")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	assert.ErrorIs(t, cs.DeleteCSR("client1"), storage.ErrNotFound)
+}
+
+func TestMemoryIndexDB_UpdateRecordAndQuery(t *testing.T) {
+	_, _, idx, sp, _, _ := newMemoryPKI(t)
+	serial1, err := sp.Next()
+	require.NoError(t, err)
+	serial2, err := sp.Next()
+	require.NoError(t, err)
+	serial3, err := sp.Next()
+	require.NoError(t, err)
+
+	expires := time.Now().Add(24 * time.Hour)
+	require.NoError(t, idx.Record(storage.IndexEntry{
+		Status:    storage.StatusValid,
+		Serial:    serial1,
+		ExpiresAt: expires,
+		Subject:   pkixName("client1"),
+	}))
+	require.NoError(t, idx.Record(storage.IndexEntry{
+		Status:    storage.StatusValid,
+		Serial:    serial2,
+		ExpiresAt: expires,
+		Subject:   pkixName("client2"),
+	}))
+
+	revokedAt := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, idx.Update(serial1, storage.StatusRevoked, revokedAt, cert.ReasonKeyCompromise))
+
+	require.NoError(t, idx.RecordAndUpdate(storage.IndexEntry{
+		Status:    storage.StatusValid,
+		Serial:    serial3,
+		ExpiresAt: expires,
+		Subject:   pkixName("client3"),
+	}, serial2, storage.StatusExpired, time.Time{}, cert.ReasonUnspecified))
+
+	all, err := idx.Query(storage.IndexFilter{})
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+
+	revokedStatus := storage.StatusRevoked
+	revoked, err := idx.Query(storage.IndexFilter{Status: &revokedStatus})
+	require.NoError(t, err)
+	require.Len(t, revoked, 1)
+	assert.Zero(t, revoked[0].Serial.Cmp(serial1))
+	assert.Equal(t, cert.ReasonKeyCompromise, revoked[0].RevocationReason)
+
+	expiredStatus := storage.StatusExpired
+	expired, err := idx.Query(storage.IndexFilter{Status: &expiredStatus})
+	require.NoError(t, err)
+	require.Len(t, expired, 1)
+	assert.Zero(t, expired[0].Serial.Cmp(serial2))
+
+	byName, err := idx.Query(storage.IndexFilter{Name: "client3"})
+	require.NoError(t, err)
+	require.Len(t, byName, 1)
+	assert.Zero(t, byName[0].Serial.Cmp(serial3))
+
+	assert.ErrorIs(t, idx.Update(big.NewInt(999), storage.StatusRevoked, revokedAt, cert.ReasonKeyCompromise), storage.ErrNotFound)
+
+	serial4, err := sp.Next()
+	require.NoError(t, err)
+	require.NoError(t, idx.RecordAndUpdate(storage.IndexEntry{
+		Status:    storage.StatusValid,
+		Serial:    serial4,
+		ExpiresAt: expires,
+		Subject:   pkixName("orphan"),
+	}, big.NewInt(999), storage.StatusRevoked, revokedAt, cert.ReasonKeyCompromise))
+
+	byName, err = idx.Query(storage.IndexFilter{Name: "orphan"})
+	require.NoError(t, err)
+	require.Len(t, byName, 1)
+	assert.Zero(t, byName[0].Serial.Cmp(serial4))
+}
+
+func TestMemorySerialProvider_SetNext(t *testing.T) {
+	_, _, _, sp, _, _ := newMemoryPKI(t)
+
+	assert.Error(t, sp.SetNext(nil))
+	assert.Error(t, sp.SetNext(big.NewInt(0)))
+
+	require.NoError(t, sp.SetNext(big.NewInt(42)))
+	next, err := sp.Next()
+	require.NoError(t, err)
+	assert.Zero(t, next.Cmp(big.NewInt(42)))
+
+	next, err = sp.Next()
+	require.NoError(t, err)
+	assert.Zero(t, next.Cmp(big.NewInt(43)))
+}
+
+func TestMemoryCRLHolder_GetBehavior(t *testing.T) {
+	_, _, _, _, crl, pk := newMemoryPKI(t)
+
+	list, err := crl.Get()
+	require.NoError(t, err)
+	assert.Empty(t, list.RevokedCertificateEntries)
+
+	_, err = pk.BuildCA()
+	require.NoError(t, err)
+	_, err = pk.BuildClientFull("client1")
+	require.NoError(t, err)
+	require.NoError(t, pk.Revoke("client1", cert.ReasonKeyCompromise))
+	crlPEM, err := pk.GenCRL()
+	require.NoError(t, err)
+
+	require.NoError(t, crl.Put(crlPEM))
+	list, err = crl.Get()
+	require.NoError(t, err)
+	require.Len(t, list.RevokedCertificateEntries, 1)
+	assert.Equal(t, 1, list.RevokedCertificateEntries[0].ReasonCode)
+
+	require.NoError(t, crl.Put([]byte("not a pem")))
+	list, err = crl.Get()
+	require.NoError(t, err)
+	assert.Empty(t, list.RevokedCertificateEntries)
+}
+
+func pkixName(cn string) pkix.Name { return pkix.Name{CommonName: cn} }

--- a/storage/validation_test.go
+++ b/storage/validation_test.go
@@ -2,6 +2,7 @@ package storage_test
 
 import (
 	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,4 +41,10 @@ func TestValidateOwnership_PropagatesErrors(t *testing.T) {
 
 	err = storage.ValidateOwnership(fakeOwnershipValidator{ownedErr: errors.New("owned-boom")})
 	require.EqualError(t, err, "owned-boom")
+}
+
+func TestHexSerial_UppercaseEvenLength(t *testing.T) {
+	require.Equal(t, "01", storage.HexSerial(big.NewInt(1)))
+	require.Equal(t, "0A", storage.HexSerial(big.NewInt(10)))
+	require.Equal(t, "0100", storage.HexSerial(big.NewInt(256)))
 }


### PR DESCRIPTION
## Summary
- add dense regression tests for public APIs in cert, storage/* and selected pki helpers
- align test file names with the source files they cover
- raise overall Go test coverage above 80%

## Coverage
- total coverage: 54.4% -> 80.5%

## Validation
- go test ./...
- go test ./... -covermode=count -coverprofile=coverage.out